### PR TITLE
chore: track octo plugin via GitHub Releases (+ OSS review fixes)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,7 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,22 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.21'
+          cache: true
+      - name: go build
+        run: go build ./...
+      - name: go test
+        run: go test -race -timeout 60s ./...
+      - name: go vet
+        run: go vet ./...

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,3 +1,19 @@
+# ═══════════════════════════════════════════════════════════════════
+# CI/CD topology — please read before editing
+# ═══════════════════════════════════════════════════════════════════
+# Source of truth:  https://github.com/Mininglamp-OSS/octo-version-sync
+# CI/CD runner:     codex.mlamp.cn/dmwork/octo-version-sync (GitLab EE)
+# Sync mechanism:   GitLab Pull Mirror (every ~5 min from GitHub)
+#
+# Code changes → push to GitHub. GitLab pulls automatically and
+# triggers this pipeline. Do NOT push to GitLab directly — those
+# commits get overwritten by the next mirror pull.
+#
+# Why double-repo: GitHub hosts canonical code + lightweight PR CI
+# (.github/workflows/ci.yml). GitLab owns TCR image build + ArgoCD
+# deploy because internal infra (TCR namespace, deploy-files repo,
+# K8s secrets) lives behind the VPN and stays on GitLab runners.
+# ═══════════════════════════════════════════════════════════════════
 stages:
   - build
   - package

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Default component set (see `components.json`):
 | `codex` | `github:openai/codex` | OpenAI Codex CLI |
 | `hermes` | `github:NousResearch/hermes-agent` | Hermes Agent |
 | `openclaw` | `npm:openclaw` | OpenClaw runtime (npm) |
-| `openclaw-channel-dmwork` | `npm:openclaw-channel-dmwork` | OpenClaw channel plugin (legacy npm name; the rebranded plugin lives at `clawhub:octo`) |
+| `openclaw-channel-octo` | `npm:openclaw-channel-octo` | OpenClaw channel plugin (the rebranded plugin; also published to ClawHub as `clawhub:octo`) |
 
 Add a component by editing `components.json` — the next scan cycle
 picks it up automatically (no redeploy needed).
@@ -151,6 +151,27 @@ Alpine base):
 ```bash
 docker build -t octo-version-sync:dev .
 ```
+
+## 🔀 Repository topology
+
+`octo-version-sync` lives in two places. They are not equal peers — one
+is the canonical source, the other is a runner mirror:
+
+| Repository | Role | What you do here |
+|---|---|---|
+| **`github.com/Mininglamp-OSS/octo-version-sync`** | **Source of truth** (this repo) | Edit code, open PRs, review |
+| `codex.mlamp.cn/dmwork/octo-version-sync` (GitLab EE) | Pull mirror + CI/CD runner | Watch pipeline logs |
+
+The GitLab project pulls from GitHub on a ~5 min interval, triggers
+`.gitlab-ci.yml` (TCR image build → deploy-files render → ArgoCD sync).
+**Never push directly to the GitLab side** — those commits get
+overwritten on the next mirror pull.
+
+Why split the two: GitHub hosts canonical code and lightweight PR CI
+(`.github/workflows/ci.yml` — `go build` + `go test`). The full
+build-and-deploy pipeline stays on GitLab because the internal infra
+it touches (TCR namespace, deploy-files repo, K8s secrets) lives
+behind the VPN.
 
 ## 🔗 OCTO Ecosystem
 

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Default component set (see `components.json`):
 | `codex` | `github:openai/codex` | OpenAI Codex CLI |
 | `hermes` | `github:NousResearch/hermes-agent` | Hermes Agent |
 | `openclaw` | `npm:openclaw` | OpenClaw runtime (npm) |
-| `openclaw-channel-octo` | `npm:openclaw-channel-octo` | OpenClaw channel plugin (the rebranded plugin; also published to ClawHub as `clawhub:octo`) |
+|  `octo` | `github:Mininglamp-OSS/openclaw-channel-octo` | OpenClaw channel plugin (the rebranded plugin; also published to ClawHub as `clawhub:octo`) |
 
 Add a component by editing `components.json` — the next scan cycle
 picks it up automatically (no redeploy needed).

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,7 +96,7 @@ curl -XPOST \
 | `codex` | `github:openai/codex` | OpenAI Codex CLI |
 | `hermes` | `github:NousResearch/hermes-agent` | Hermes Agent |
 | `openclaw` | `npm:openclaw` | OpenClaw 运行时（npm） |
-| `openclaw-channel-octo` | `npm:openclaw-channel-octo` | OpenClaw channel 插件（改名后的版本；同时也发布到 ClawHub 上的 `clawhub:octo`） |
+|  `octo` | `github:Mininglamp-OSS/openclaw-channel-octo` | OpenClaw channel 插件（改名后的版本；同时也发布到 ClawHub 上的 `clawhub:octo`） |
 
 新增组件只需编辑 `components.json` —— 下一轮扫描自动生效，无需重启。
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -96,7 +96,7 @@ curl -XPOST \
 | `codex` | `github:openai/codex` | OpenAI Codex CLI |
 | `hermes` | `github:NousResearch/hermes-agent` | Hermes Agent |
 | `openclaw` | `npm:openclaw` | OpenClaw 运行时（npm） |
-| `openclaw-channel-dmwork` | `npm:openclaw-channel-dmwork` | OpenClaw channel 插件（npm 老名字；改名后的版本走 `clawhub:octo`） |
+| `openclaw-channel-octo` | `npm:openclaw-channel-octo` | OpenClaw channel 插件（改名后的版本；同时也发布到 ClawHub 上的 `clawhub:octo`） |
 
 新增组件只需编辑 `components.json` —— 下一轮扫描自动生效，无需重启。
 
@@ -146,6 +146,27 @@ make build
 ```bash
 docker build -t octo-version-sync:dev .
 ```
+
+## 🔀 仓库拓扑
+
+`octo-version-sync` 同时存在于两个地方，**不是对等关系** —— 一个是
+代码来源真相，另一个只是触发 CI/CD 的镜像：
+
+| 仓库 | 角色 | 在这里做什么 |
+|---|---|---|
+| **`github.com/Mininglamp-OSS/octo-version-sync`** | **Source of truth**（本仓） | 写代码 / 开 PR / review |
+| `codex.mlamp.cn/dmwork/octo-version-sync`（GitLab EE） | Pull mirror + CI/CD runner | 看 pipeline 日志 |
+
+GitLab 那侧每 ~5 分钟从 GitHub Pull Mirror 一次，触发
+`.gitlab-ci.yml`（TCR 镜像构建 → deploy-files 渲染 → ArgoCD 同步）。
+**不要往 GitLab 那侧直接 push** —— 那些 commit 会被下一次 mirror pull
+覆盖掉。
+
+为什么拆两边：GitHub 承载代码 + 轻量 PR CI
+（`.github/workflows/ci.yml` —— `go build` + `go test`）。完整的
+build & deploy 流水线留在 GitLab，因为它依赖的内部基础设施
+（TCR namespace / deploy-files 仓 / K8s secrets）都在 VPN 内、跑在
+GitLab runner 上。
 
 ## 🔗 OCTO 生态
 

--- a/components.json
+++ b/components.json
@@ -4,5 +4,5 @@
   {"name": "codex", "source": "github:openai/codex"},
   {"name": "hermes", "source": "github:NousResearch/hermes-agent"},
   {"name": "openclaw", "source": "npm:openclaw"},
-  {"name": "openclaw-channel-dmwork", "source": "npm:openclaw-channel-dmwork"}
+  {"name": "openclaw-channel-octo", "source": "npm:openclaw-channel-octo"}
 ]

--- a/components.json
+++ b/components.json
@@ -4,5 +4,5 @@
   {"name": "codex", "source": "github:openai/codex"},
   {"name": "hermes", "source": "github:NousResearch/hermes-agent"},
   {"name": "openclaw", "source": "npm:openclaw"},
-  {"name": "openclaw-channel-octo", "source": "npm:openclaw-channel-octo"}
+  {"name": "octo", "source": "github:Mininglamp-OSS/openclaw-channel-octo"}
 ]

--- a/internal/model.go
+++ b/internal/model.go
@@ -40,5 +40,5 @@ var DefaultComponents = []ComponentDef{
 	{Name: "claude", Source: "github:anthropics/claude-code"},
 	{Name: "hermes", Source: "github:NousResearch/hermes-agent"},
 	{Name: "openclaw", Source: "npm:openclaw"},
-	{Name: "openclaw-channel-octo", Source: "npm:openclaw-channel-octo"},
+	{Name: "octo", Source: "github:Mininglamp-OSS/openclaw-channel-octo"},
 }

--- a/internal/model.go
+++ b/internal/model.go
@@ -40,5 +40,5 @@ var DefaultComponents = []ComponentDef{
 	{Name: "claude", Source: "github:anthropics/claude-code"},
 	{Name: "hermes", Source: "github:NousResearch/hermes-agent"},
 	{Name: "openclaw", Source: "npm:openclaw"},
-	{Name: "openclaw-channel-dmwork", Source: "npm:openclaw-channel-dmwork"},
+	{Name: "openclaw-channel-octo", Source: "npm:openclaw-channel-octo"},
 }


### PR DESCRIPTION
## Summary

- Track the `octo` channel plugin via **GitHub Releases** of `Mininglamp-OSS/openclaw-channel-octo` instead of the npm registry — eliminates the npm-vs-ClawHub version skew now that `git push --tags` on that repo auto-creates the GitHub Release and auto-publishes to ClawHub.
- 0 fetcher code change — the existing `github:` source dispatch already handles it.
- This PR also lands the previously-uncommitted OSS review fixes (npm package rename to `openclaw-channel-octo`, GitHub Actions CI workflow, repository topology docs, dependabot `github-actions` ecosystem). Those have been ready locally; this is the first `main` push since.

## Background — why GitHub Release is the right source

The `Mininglamp-OSS/openclaw-channel-octo` repo now has a `tag → GitHub Release → ClawHub publish` workflow. The GitHub Release object is therefore the single source of truth that everything else descends from:

- ClawHub package (`clawhub:octo`) is published from the same artifact.
- npm package (if synced) is downstream of the Release.
- The daemon's installed plugin version traces back to the same Release.

Anchoring `octo-version-sync` here means there is only ever **one** "latest version" number across the fleet.

## What was wrong with `npm:openclaw-channel-octo`

| Channel | latest at time of audit |
|---|---|
| npm `openclaw-channel-octo` | `1.0.0` (stale) |
| ClawHub `octo` | `1.0.8` (current) |
| daemon-reported installed | `1.0.7` |

`octo-version-sync` was pointing at the **wrong** source — npm — so the Web UI either showed no upgrade hint (because npm 1.0.0 looks older than the daemon's 1.0.7) or worse, an inverted "downgrade" suggestion.

After this PR, `octo-version-sync` reads `v1.0.8` directly from the GitHub Release.

## Verification

Locally rebuilt and ran with `--github-token`:

```
[INFO] octo fetched: 1.0.8
[INFO] sync complete, 5 component(s) updated
```

Output `version.json`:

```json
{
  "octo": {
    "latest_version": "1.0.8",
    "release_meta": {
      "tag": "v1.0.8",
      "assets": [
        {
          "name": "octo-1.0.8.tgz",
          "url": "https://github.com/Mininglamp-OSS/openclaw-channel-octo/releases/download/v1.0.8/octo-1.0.8.tgz",
          "size": 1695593,
          "kind": "archive"
        }
      ]
    },
    "source": "github:Mininglamp-OSS/openclaw-channel-octo",
    "status": "ok"
  }
}
```

## Test plan

- [x] `go build ./...`
- [x] Local `version-sync --store=file --github-token=...` fetches `octo` 1.0.8 with full asset metadata
- [ ] After merge: GitLab Pull Mirror picks up within ~5 min → GitLab CI builds image → ArgoCD deploys → production COS `version.json` `octo` updates from absent → `1.0.8`
- [ ] OCTO Web Runtimes page shows `Octo Plugin 1.0.7 → 1.0.8` upgrade hint