### PR TITLE
chore(ci): add check-sprint workflow

### DIFF
--- a/.github/workflows/check-sprint.yml
+++ b/.github/workflows/check-sprint.yml
@@ -1,0 +1,18 @@
+name: Check Sprint
+
+on:
+  pull_request_target: # zizmor: ignore[dangerous-triggers] metadata-only automation; no PR code executed
+    types: [opened, synchronize, reopened, ready_for_review, edited]
+    branches: [main]
+
+permissions: {}
+
+jobs:
+  check-sprint:
+    if: ${{ !github.event.pull_request.draft }}
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-check-sprint.yml@main
+    with:
+      pr-number: ${{ github.event.pull_request.number }}
+      repo-name: ${{ github.repository }}
+    secrets:
+      PROJECT_TOKEN: ${{ secrets.PROJECT_TOKEN }}


### PR DESCRIPTION
## Summary

Adds `check-sprint.yml` to enforce Sprint assignment on all PRs. Thin caller to the org reusable `reusable-check-sprint.yml@main`.