### PR TITLE
ci: add timeout-minutes to all CI jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   build-and-test:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5


### PR DESCRIPTION
## What

Add `timeout-minutes` to every CI job that is missing one.

**Timeout values:**
- `changes` (path detection): **5 min**
- `build` / `vet` / `lint` / custom lint jobs: **15 min**
- `test` / `build-and-test` / `npm-test`: **30 min**

## Why

Without explicit timeouts, a stuck test or build will run until GitHub's
6-hour default kills it — wasting runner capacity and delaying feedback.

Ref: Mininglamp-OSS workflow optimization T04.
