### PR TITLE
ci: pin all GitHub Actions to exact SHA digests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,8 +9,8 @@ jobs:
   build-and-test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-go@v5
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+      - uses: actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5
         with:
           go-version: '1.21'
           cache: true


### PR DESCRIPTION
## What

Replace all tag-based action references (`@v4`/`@v5`) with SHA-pinned versions plus version comments.

## Why

Tag refs can be force-pushed, creating a supply chain attack vector. SHA pinning ensures the exact code version is used. This aligns with the org standard already followed by other Mininglamp-OSS repos.

## Changes

- `actions/checkout@v4` → `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4`
- `actions/setup-go@v5` → `actions/setup-go@40f1582b2485089dde7abd97c1529aa768e1baff # v5`

## Verification

```
grep -r '@v[0-9]' .github/workflows/
```
Returns empty — all actions are now SHA-pinned.