### PR TITLE
ci: add top-level permissions to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary

Add explicit `permissions: contents: read` to ci.yml.

Without a top-level `permissions` declaration, the workflow inherits the
repository default, which may grant broader permissions than needed.
Explicit least-privilege permissions follow GitHub security best practices
and align with the org standard established in `Mininglamp-OSS/.github`.