### PR TITLE
ci: add history check (reject orphan-branch PRs)

### DIFF
--- a/.github/workflows/history-check.yml
+++ b/.github/workflows/history-check.yml
@@ -1,0 +1,26 @@
+# History check — reject PRs with no common ancestor on the target branch.
+#
+# Calls the org-wide reusable workflow:
+#   Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml
+#
+# Why: GitHub's merge UI does NOT refuse merges of unrelated histories.
+# An orphan-branch PR (e.g. `git checkout --orphan` or a re-initialized
+# `.git/`) merges cleanly but grafts a parent-less root commit into the
+# target branch, collapsing `git blame` for every file in that snapshot
+# onto a single commit. Precedent: hermes-agent PR #25045 (May 2026).
+
+name: History Check
+
+on:
+  pull_request:
+    branches: [main]
+
+# Caller permissions act as an upper bound for the reusable workflow.
+# The reusable workflow needs `contents: read` to run `actions/checkout`,
+# so we must grant it here too (a top-level `{}` would block startup).
+permissions:
+  contents: read
+
+jobs:
+  history:
+    uses: Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml@main


### PR DESCRIPTION
## Summary

Wire up the org-wide reusable history check that rejects PRs with no common ancestor on the target branch.

## Why

GitHub's merge UI does not refuse merges of unrelated histories. An orphan-branch PR (created via `git checkout --orphan` or a re-initialized `.git/`) merges cleanly but grafts a parent-less root commit into the target branch, collapsing `git blame` for every file in that snapshot onto a single commit.

**Real-world precedent**: hermes-agent PR #25045 (May 2026) re-rooted blame on ~1500 files via an undetected orphan branch.

## What

Add `.github/workflows/history-check.yml` (~26 lines) that calls:

```yaml
uses: Mininglamp-OSS/.github/.github/workflows/reusable-history-check.yml@main
```

The reusable workflow (.github#62, merged 2026-06-04) uses `git merge-base` to verify common ancestry; on failure it prints a diagnostic error with cause and fix.

## Caller permissions

`permissions: contents: read` at caller top-level — required to authorize the reusable workflow's checkout step. A top-level `{}` was tested in the pilot and caused `startup_failure`.

## Cost

- Per-PR runtime: ~5-15s (full clone needed for `git merge-base`)
- No secrets

## Verification

- Pilot PR Mininglamp-OSS/octo-lib#64 — History Check job ran in 9s, status `success`
- Caller workflow uses pinned reusable workflow @main
- Triggers only on `pull_request` against `main`

## Context

Part of **T14 — reusable-history-check consumer rollout**, post-merge of Mininglamp-OSS/.github#62.

cc @lml2468