### PR TITLE
chore: deprecate octo-version-sync (manual fleet maintenance)

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,21 @@
 
 ---
 
+> ## ⚠️ DEPRECATED(2026-06)
+>
+> **octo-version-sync 已退役,不再部署运行。** 它的唯一消费者 —— octo-fleet 的
+> COS 版本同步器(`modules/runtime/version_sync.go`)—— 已移除。fleet 的
+> `runtime_latest_version` 表现改为**人工维护**,通过 internal 端点
+> `POST /v1/internal/runtime-latest-versions`(鉴权 header `X-Runtime-Admin-Token`,
+> 值为 `OCTO_RUNTIME_ADMIN_TOKEN`)写入。
+>
+> - 退役详情(最后产物来源、components 差异、部署下线清单):见 [`docs/DEPRECATION.md`](docs/DEPRECATION.md)
+> - 人工维护版本/release_meta 的操作手册:见 [`docs/MANUAL-VERSION-SOP.md`](docs/MANUAL-VERSION-SOP.md)
+>
+> 本仓库代码保留作历史参考,**不接受新功能**。
+
+---
+
 > 🌐 **Read in**: **English** · [简体中文](README.zh.md)
 
 # 🔄 Octo Version Sync

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@
 >
 > **octo-version-sync 已退役,不再部署运行。** 它的唯一消费者 —— octo-fleet 的
 > COS 版本同步器(`modules/runtime/version_sync.go`)—— 已移除。fleet 的
-> `runtime_latest_version` 表现改为**人工维护**,通过 internal 端点
+> `runtime_latest_version` 表已改为**人工维护**,通过 internal 端点
 > `POST /v1/internal/runtime-latest-versions`(鉴权 header `X-Runtime-Admin-Token`,
 > 值为 `OCTO_RUNTIME_ADMIN_TOKEN`)写入。
 >

--- a/README.zh.md
+++ b/README.zh.md
@@ -23,6 +23,21 @@
 
 ---
 
+> ## ⚠️ 已退役(2026-06)
+>
+> **octo-version-sync 已退役,不再部署运行。** 它的唯一消费者 —— octo-fleet 的
+> COS 版本同步器(`modules/runtime/version_sync.go`)—— 已移除。fleet 的
+> `runtime_latest_version` 表现改为**人工维护**,通过 internal 端点
+> `POST /v1/internal/runtime-latest-versions`(鉴权 header `X-Runtime-Admin-Token`,
+> 值为 `OCTO_RUNTIME_ADMIN_TOKEN`)写入。
+>
+> - 退役详情(最后产物来源、components 差异、部署下线清单):见 [`docs/DEPRECATION.md`](docs/DEPRECATION.md)
+> - 人工维护版本/release_meta 的操作手册:见 [`docs/MANUAL-VERSION-SOP.md`](docs/MANUAL-VERSION-SOP.md)
+>
+> 本仓库代码保留作历史参考,**不接受新功能**。
+
+---
+
 > 🌐 **语言**: [English](README.md) · **简体中文**
 
 # 🔄 Octo Version Sync（简体中文）

--- a/README.zh.md
+++ b/README.zh.md
@@ -27,7 +27,7 @@
 >
 > **octo-version-sync 已退役,不再部署运行。** 它的唯一消费者 —— octo-fleet 的
 > COS 版本同步器(`modules/runtime/version_sync.go`)—— 已移除。fleet 的
-> `runtime_latest_version` 表现改为**人工维护**,通过 internal 端点
+> `runtime_latest_version` 表已改为**人工维护**,通过 internal 端点
 > `POST /v1/internal/runtime-latest-versions`(鉴权 header `X-Runtime-Admin-Token`,
 > 值为 `OCTO_RUNTIME_ADMIN_TOKEN`)写入。
 >

--- a/docs/DEPRECATION.md
+++ b/docs/DEPRECATION.md
@@ -1,0 +1,67 @@
+# octo-version-sync 退役说明(2026-06)
+
+## 背景
+
+octo-version-sync 是「上游版本聚合器」:每隔几分钟轮询 GitHub Releases / npm,
+把规范化的 `version.json`(含各 component 的 `latest_version` + `release_meta`)
+写到对象存储(COS),供 octo-fleet 拉取进 `runtime_latest_version` 表。
+
+2026-06 的 runtime 线调整后:
+
+- octo-fleet 的 COS 同步器 `modules/runtime/version_sync.go` **已删除**。
+- `runtime_latest_version` 表改为**人工维护**(见 [`MANUAL-VERSION-SOP.md`](MANUAL-VERSION-SOP.md))。
+- 因此 version-sync 已无下游消费者,停止部署。
+
+## 最后一次产物来源
+
+退役时 version-sync 产出的 `version.json` 来源(`components.json`):
+
+| component | source |
+|---|---|
+| octo-daemon | github:Mininglamp-OSS/octo-daemon-cli |
+| claude | github:anthropics/claude-code |
+| codex | github:openai/codex |
+| hermes | github:NousResearch/hermes-agent |
+| openclaw | npm:openclaw |
+| octo | github:Mininglamp-OSS/openclaw-channel-octo |
+
+## ⚠️ components.json 与 DefaultComponents 的差异(人工接管须知)
+
+代码里有两份 component 列表,**内容不一致**,接管时勿混淆:
+
+| component | components.json(生产用) | DefaultComponents(model.go fallback) |
+|---|---|---|
+| octo-daemon | ✓ | ✓ |
+| octo-version-sync | ✗ | ✓(fallback 历史默认项) |
+| claude | ✓ | ✓ |
+| codex | ✓ | ✗ |
+| hermes | ✓ | ✓ |
+| openclaw | ✓ | ✓ |
+| octo | ✓ | ✓ |
+
+- 生产实际跑的是 `components.json`(`--components` 参数指向它);`DefaultComponents`
+  (`internal/model.go`)仅在未提供该文件时兜底。
+- **codex/hermes 注意**:runtime 线本期已从 fleet/daemon/web 全栈移除 codex/hermes
+  (只放行 claude+openclaw)。version-sync 的 components.json 仍含 codex/hermes 是
+  历史产物记录;人工维护 `runtime_latest_version` 时**只需维护 active provider
+  (claude/openclaw)+ octo-daemon + octo(插件)**,不必再维护 codex/hermes。
+
+## 部署下线清单(运维执行)
+
+version-sync 走独立 GitLab deploy-files 分支 + ArgoCD,**不在 octo-deployment kustomize 内**。下线需:
+
+- [ ] **先禁用 CI/CD 自动部署**(否则后续 main/tag pipeline 会重建以下资源):
+      - 禁用 GitLab Pull Mirror / CI deploy pipeline(`.gitlab-ci.yml` 的 `sync_code` + `argocd_sync` stage 在 main/develop/tags 触发)
+      - 冻结 / 移除部署变量:`CODE_TOKEN`、`ARGOCD_TOKEN` 等
+      - 确认后续 main/tag 推送不再写 deploy-files 分支
+- [ ] 停止 / 删除 ArgoCD app:`octo-version-sync-dev`、`octo-version-sync-prod`
+- [ ] 删除 deploy-files 仓库分支:`octo-version-sync-dev`、`octo-version-sync-prod`
+- [ ] 删除 K8s namespace 下的 deployment + service(`octo-version-sync-*`)
+- [ ] 回收 secret:`octo-version-sync-secrets-*`(COS URL/ID/Key、GitHub token、trigger token)
+- [ ] (可选)归档 TCR 镜像 `.../dmwork/octo-version-sync`
+- [ ] COS 上的旧 `version-sync/version.json` 可保留作历史,fleet 已不再读取。
+
+## 回滚
+
+若需临时恢复自动同步:重新部署 version-sync + 在 fleet 恢复 `version_sync.go`
+(从该改动之前的 git 历史取回)。但优先用人工 SOP,不建议回滚。

--- a/docs/MANUAL-VERSION-SOP.md
+++ b/docs/MANUAL-VERSION-SOP.md
@@ -1,0 +1,109 @@
+# 人工维护 runtime_latest_version SOP(替代 octo-version-sync)
+
+version-sync 退役后,octo-fleet 的 `runtime_latest_version` 表改为人工维护。
+本文档是发布新版本时更新该表的操作手册。
+
+## 何时需要更新
+
+- claude / openclaw 发布新版本(provider 升级提示 + 升级 gate 读此表)。
+- octo-daemon 发布新版本(**daemon 自升级必须有 `release_meta`**:assets + checksums)。
+- octo 插件(openclaw-channel-octo)发布新版本。
+
+> codex/hermes 已退役,**不需要**维护。
+
+## 端点
+
+```
+POST /v1/internal/runtime-latest-versions
+X-Runtime-Admin-Token: $OCTO_RUNTIME_ADMIN_TOKEN
+Content-Type: application/json
+```
+
+校验(fleet `upsertLatestVersionAdmin`):`component` 必须 ∈ {octo-daemon, octo,
+active provider(claude/openclaw)};`latest_version` 须匹配
+`^v?\d+\.\d+(\.\d+)?([-+].+)?$`;`release_meta` 可选,省略 / `null` 时 fleet
+**保留旧值**(不清空)。
+
+> ⚠️ **fleet 只校验 `release_meta` 是合法 JSON,不校验 schema / asset 覆盖 / checksum 完整性。**
+> 即 `release_meta: []`、缺 assets、缺 checksums 都能写入成功 —— 错误要到 daemon 升级建任务时
+> 才暴露为 `invalid release metadata` / 找不到 asset / 缺 checksum。**200 OK 不代表 daemon 能升级**,
+> octo-daemon 发布必须人工对照下方结构自检。
+
+## 场景 A:provider 版本(claude / openclaw)—— 不需要 release_meta
+
+provider 升级时 daemon 调各自的 update 子命令(`claude update`、`openclaw update --yes
+--timeout 600 --tag <target>`),不需要 url/checksum;fleet 只读 `latest_version`、建任务时
+download_url/checksum 留空。只填版本号:
+
+```json
+{
+  "component": "claude",
+  "latest_version": "2.2.0"
+}
+```
+
+(省略 `release_meta`,fleet 不动旧值。)
+
+## 场景 B:octo-daemon 自升级 —— 必须填完整 release_meta
+
+daemon 自升级要 fleet 提供下载 asset + checksum。从 octo-daemon-cli 的 GitHub
+Release 页面取每个平台的 archive + 其 sha256(GoReleaser 生成,archive 名模板
+`{{.ProjectName}}_{{.Version}}_{{.Os}}_{{.Arch}}.tar.gz`,checksum 在 `checksums.txt`)。
+**`name` 必须逐字复制 Release 页面的 asset 名,不要手写猜测**:
+
+```json
+{
+  "component": "octo-daemon",
+  "latest_version": "0.3.0",
+  "release_meta": {
+    "tag": "v0.3.0",
+    "assets": [
+      {
+        "name": "octo-daemon_0.3.0_darwin_arm64.tar.gz",
+        "url": "https://github.com/Mininglamp-OSS/octo-daemon-cli/releases/download/v0.3.0/octo-daemon_0.3.0_darwin_arm64.tar.gz",
+        "size": 2827327,
+        "os": "darwin",
+        "arch": "arm64",
+        "kind": "archive"
+      }
+    ],
+    "checksums": {
+      "octo-daemon_0.3.0_darwin_arm64.tar.gz": "sha256:e87cb7..."
+    }
+  }
+}
+```
+
+字段要求(对齐 fleet `releaseMetaJSON` / daemon 升级匹配逻辑):
+
+- daemon 按 `os` + `arch` 找 `kind=="archive"` 的 asset;**每个目标平台都要有一条**
+  (darwin/linux × arm64/amd64 等,按实际发布的平台)。
+- `checksums` 的 key 必须**逐字等于**对应 asset 的 `name`,值为 `sha256:<hex>`。
+- 缺 `release_meta` 或缺匹配 asset/checksum → daemon 升级报 `no release metadata available` /
+  找不到 asset / 缺 checksum,升级按钮取错。
+
+## 场景 C:octo 插件版本
+
+```json
+{
+  "component": "octo",
+  "latest_version": "0.7.0"
+}
+```
+
+(daemon 当前通过 `npx -y create-openclaw-octo install` 执行 octo 插件升级;fleet 插件
+路径只读 `latest_version`,不需要 release_meta。)
+
+## 校验更新成功
+
+更新后在 web Runtimes 页确认对应 component 的版本提示 / 升级按钮显示正确;
+或直接查 fleet `runtime_latest_version` 表。注意场景 B 的 `200 OK` 不代表可升级,
+需实际触发一次 daemon 升级或人工核对 assets/checksums 完整。
+
+## 获取 sha256 的方法
+
+```bash
+# 下载 asset 后
+shasum -a 256 octo-daemon_0.3.0_darwin_arm64.tar.gz
+# 或从 GitHub Release 的 checksums.txt 取(GoReleaser 生成)
+```


### PR DESCRIPTION
## What (第1章 / version-sync 退役)
octo-version-sync 退役:fleet 已停 COS 同步器,`runtime_latest_version` 改人工维护。

- README 标记 deprecated + 指向人工维护 SOP;记录最后产物来源、components 差异、下线 checklist。纯文档,无代码改动。